### PR TITLE
expose textEncoder to the global object

### DIFF
--- a/util.js
+++ b/util.js
@@ -717,3 +717,10 @@ exports.callbackify = callbackify;
 const textEncoding = require('text-encoding-polyfill');
 exports.TextEncoder = textEncoding.TextEncoder;
 exports.TextDecoder = textEncoding.TextDecoder;
+
+Object.defineProperty(global, 'TextEncoder', {
+  value: textEncoding.TextEncoder,
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});


### PR DESCRIPTION
replicate the v11.0.0 nodejs change to expose textEncoder to the global object.